### PR TITLE
F/6533 get output configurations from  app or request locals

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 This is a Koop output plugin that transforms data from Koop Provider into a CSV file.
 
 ## Use
-The plugin uses highly customizable CSV template in JSON for field mapping which needs to be passed via Koop instance in `res.locals.csvTemplate`, `koop.server.locals.csvTemplateTransforms`. [adlib](https://github.com/Esri/adlib) is used to interpolate template. `koop.server.locals.csvFileName` is used for naming CSV filename. 
+The plugin uses highly customizable CSV template in JSON for field mapping with provider's data which can be passed via Koop instance. The options for the plugin are `csvTemplate`, `csvTemplateTransforms` and `csvFileName`. Both `csvTemplate`, `csvTemplateTransforms` can be request (`res.locals`) specific and/or application (`app.locals`) specific set in Koop server middleware. `csvFileName` is request (`res.locals`) specific used for naming CSV filename. 
+
+[adlib](https://github.com/Esri/adlib) is used to interpolate template.
 
 
 Visit the [KoopJS docs](https://koopjs.github.io/docs/basics/what-is-koop) for instructions on building and deploying a Koop app.

--- a/example-app/package-lock.json
+++ b/example-app/package-lock.json
@@ -65,6 +65,7 @@
     "@koopjs/koop-output-csv": {
       "version": "file:../build",
       "requires": {
+        "adlib": "^3.0.7",
         "lodash": "^4.17.21",
         "tslib": "~2.3.0"
       },

--- a/src/csv/compile-csv-feed.ts
+++ b/src/csv/compile-csv-feed.ts
@@ -12,7 +12,7 @@ type Feature = {
 export function compileCsvFeedEntry(
   geojsonFeature: Feature | undefined,
   feedTemplate: CsvDatasetTemplate,
-  feedTemplateTransforms: TransformsList): string {
+  feedTemplateTransforms: TransformsList | undefined): string {
   try {
     const csvItem = generateCsvItem(geojsonFeature, feedTemplate, feedTemplateTransforms);
     return csvItem;
@@ -21,7 +21,7 @@ export function compileCsvFeedEntry(
   }
 }
 
-function generateCsvItem(geojsonFeature: Feature, feedTemplate: CsvDatasetTemplate, feedTemplateTransforms: TransformsList): string {
+function generateCsvItem(geojsonFeature: Feature, feedTemplate: CsvDatasetTemplate, feedTemplateTransforms: TransformsList | undefined): string {
   const { properties } = geojsonFeature;
 
   const interpolatedFields = adlib(

--- a/src/csv/compile-csv-feed.ts
+++ b/src/csv/compile-csv-feed.ts
@@ -12,7 +12,7 @@ type Feature = {
 export function compileCsvFeedEntry(
   geojsonFeature: Feature | undefined,
   feedTemplate: CsvDatasetTemplate,
-  feedTemplateTransforms: TransformsList | undefined): string {
+  feedTemplateTransforms?: TransformsList): string {
   try {
     const csvItem = generateCsvItem(geojsonFeature, feedTemplate, feedTemplateTransforms);
     return csvItem;
@@ -21,7 +21,7 @@ export function compileCsvFeedEntry(
   }
 }
 
-function generateCsvItem(geojsonFeature: Feature, feedTemplate: CsvDatasetTemplate, feedTemplateTransforms: TransformsList | undefined): string {
+function generateCsvItem(geojsonFeature: Feature, feedTemplate: CsvDatasetTemplate, feedTemplateTransforms?: TransformsList): string {
   const { properties } = geojsonFeature;
 
   const interpolatedFields = adlib(

--- a/src/csv/index.ts
+++ b/src/csv/index.ts
@@ -3,7 +3,7 @@ import { compileCsvFeedEntry } from './compile-csv-feed';
 import { TransformsList } from 'adlib';
 import * as _ from 'lodash';
 
-export function getCsvDataStream(feedTemplate: Record<string, any>, feedTemplateTransforms: TransformsList | undefined) {
+export function getCsvDataStream(feedTemplate: Record<string, any>, feedTemplateTransforms?: TransformsList) {
   const csvHeaders = getCsvHeaders(feedTemplate);
 
   const streamFormatter = (chunk) => {

--- a/src/csv/index.ts
+++ b/src/csv/index.ts
@@ -3,7 +3,7 @@ import { compileCsvFeedEntry } from './compile-csv-feed';
 import { TransformsList } from 'adlib';
 import * as _ from 'lodash';
 
-export function getCsvDataStream(feedTemplate: Record<string, any>, feedTemplateTransforms: TransformsList) {
+export function getCsvDataStream(feedTemplate: Record<string, any>, feedTemplateTransforms: TransformsList | undefined) {
   const csvHeaders = getCsvHeaders(feedTemplate);
 
   const streamFormatter = (chunk) => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -88,6 +88,20 @@ describe('Output Plugin', () => {
       });
   });
 
+  it('should return error if CSV template is incorrect format', async () => {
+    const csvTemplate = 'test';
+    const csvFileName = 'filename';
+
+    [plugin, app] = buildPluginAndApp(csvTemplate, undefined, csvFileName);
+    await request(app)
+      .get('/csv')
+      .expect('Content-Type', /application\/json/)
+      .expect(400)
+      .expect((res) => {
+        expect(res.body).toEqual({ error: 'CSV feed template is not correct type.' });
+      });
+  });
+
   it('sets status to 500 if something blows up', async () => {
     
     plugin.model.pullStream.mockRejectedValue(Error('Couldnt get stream'));

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -24,7 +24,7 @@ function buildPluginAndApp(csvTemplate, csvTemplateTransforms, csvFileName) {
   app.get('/csv', function (req, res, next) {
     req.app.locals.csvTemplateTransforms = csvTemplateTransforms;
     res.locals.csvTemplate = csvTemplate;
-    req.app.locals.csvFileName = csvFileName;
+    res.locals.csvFileName = csvFileName;
     next();
   }, plugin.serve.bind(plugin));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export = class OutputCsv {
         throw new ServiceError('CSV feed template is not provided.', 400);
       }
 
-      if (!this.isRecord(csvTemplate)) {
+      if (!_.isPlainObject(csvTemplate)) {
         throw new ServiceError('CSV feed template is not correct type.', 400);
       }
 
@@ -38,10 +38,10 @@ export = class OutputCsv {
       const datasetStream = await this.getDatasetStream(req);
 
       datasetStream
+        .on('error', (err) => this.returnError(res, err))
         .pipe(csvStream)
         .pipe(res);
 
-      datasetStream.on('error', (err) => this.returnError(res, err));
     } catch (err) {
       this.returnError(res, err);
     }
@@ -61,10 +61,6 @@ export = class OutputCsv {
     } catch (err) {
       throw new ServiceError(err.message, err.status || 500);
     }
-  }
-
-  private isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null;
   }
 
   private getErrorResponse(err: any) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import { Request, Response } from 'express';
 import * as _ from 'lodash';
 import { version } from '../package.json';
 import { getCsvDataStream } from './csv';
-import { TransformsList } from 'adlib';
 import { ServiceError } from './csv/service-error';
 
 export = class OutputCsv {
@@ -21,12 +20,16 @@ export = class OutputCsv {
   public async serve(req: Request, res: Response) {
     res.setHeader('Content-Type', 'text/csv');
     try {
-      const csvTemplate = _.get(req, 'res.locals.csvTemplate') || _.get(req, 'app.locals.csvTemplate') as Record<string, any>;
-      const csvTemplateTransforms = _.get(req, 'res.locals.csvTemplateTransforms') || _.get(req, 'app.locals.csvTemplateTransforms') as TransformsList;
-      const csvFileName = _.get(req, 'res.locals.csvFileName', 'output');
+      const csvTemplate = req.res.locals.csvTemplate || req.app.locals.csvTemplate;
+      const csvTemplateTransforms = req.res.locals.csvTemplateTransforms || req.app.locals.csvTemplateTransforms;
+      const csvFileName = req.res.locals.csvFileName || 'output';
 
       if (!csvTemplate) {
         throw new ServiceError('CSV feed template is not provided.', 400);
+      }
+
+      if (!this.isRecord(csvTemplate)) {
+        throw new ServiceError('CSV feed template is not correct type.', 400);
       }
 
       res.setHeader('Content-Disposition', `attachment; filename=${csvFileName}.csv`);
@@ -58,6 +61,10 @@ export = class OutputCsv {
     } catch (err) {
       throw new ServiceError(err.message, err.status || 500);
     }
+  }
+
+  private isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
   }
 
   private getErrorResponse(err: any) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,8 @@ export = class OutputCsv {
   public async serve(req: Request, res: Response) {
     res.setHeader('Content-Type', 'text/csv');
     try {
-      const csvTemplate = _.get(req, 'app.locals.csvTemplate') || _.get(req, 'res.locals.csvTemplate') as Record<string, any>;
-      const csvTemplateTransforms = _.get(req, 'app.locals.csvTemplateTransforms') || _.get(req, 'res.locals.csvTemplateTransforms') as TransformsList;
+      const csvTemplate = _.get(req, 'res.locals.csvTemplate') || _.get(req, 'app.locals.csvTemplate') as Record<string, any>;
+      const csvTemplateTransforms = _.get(req, 'res.locals.csvTemplateTransforms') || _.get(req, 'app.locals.csvTemplateTransforms') as TransformsList;
       const csvFileName = _.get(req, 'res.locals.csvFileName', 'output');
 
       if (!csvTemplate) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,9 @@ export = class OutputCsv {
   public async serve(req: Request, res: Response) {
     res.setHeader('Content-Type', 'text/csv');
     try {
-      const csvTemplate = _.get(req, 'res.locals.csvTemplate') as Record<string, any>;
-      const csvTemplateTransforms = _.get(req, 'app.locals.csvTemplateTransforms') as TransformsList;
-      const csvFileName = _.get(req, 'app.locals.csvFileName', 'output');
+      const csvTemplate = _.get(req, 'app.locals.csvTemplate') || _.get(req, 'res.locals.csvTemplate') as Record<string, any>;
+      const csvTemplateTransforms = _.get(req, 'app.locals.csvTemplateTransforms') || _.get(req, 'res.locals.csvTemplateTransforms') as TransformsList;
+      const csvFileName = _.get(req, 'res.locals.csvFileName', 'output');
 
       if (!csvTemplate) {
         throw new ServiceError('CSV feed template is not provided.', 400);


### PR DESCRIPTION
Output options such as `csvTemplate` and `csvTemplateTransforms` can be obtained either from `app.locals`(application-wide specific) or  from `request.res.locals` (request specific). The name of CSV output file can be obtained from `request.res.locals` (request specific).

Related: https://devtopia.esri.com/dc/hub/issues/6533