### PR TITLE
encode filename

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export = class OutputCsv {
         throw new ServiceError('CSV feed template is not correct type.', 400);
       }
 
-      res.setHeader('Content-Disposition', `attachment; filename=${csvFileName}.csv`);
+      res.setHeader('Content-Disposition', `attachment; filename=${encodeURI(csvFileName)}.csv`);
 
       const { csvStream } = getCsvDataStream(csvTemplate, csvTemplateTransforms);
       const datasetStream = await this.getDatasetStream(req);


### PR DESCRIPTION
This PR uses `encodeURI` to encode file name of csv file. Not encoding the filename will cause error like in the bug with content-disposition

https://devtopia.esri.com/dc/hub/issues/12147